### PR TITLE
Use the same logic for generating nonce as poloniex does self

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -320,8 +320,8 @@ class Client implements ClientContract
      */
     public function trading(array $parameters = [])
     {
-        $mt = (string) microtime(true);
-        $parameters['nonce'] = intval(substr(str_replace('.', '', $mt), 0, 13));
+        $mt = explode(' ', microtime());
+        $parameters['nonce'] = $mt[1].substr($mt[0], 2, 6);
 
         $post = http_build_query(array_filter($parameters), '', '&');
         $sign = hash_hmac('sha512', $post, $this->secret);


### PR DESCRIPTION
In their example https://poloniex.com/support/api/ php class they use this to generate nonce.
I was having problems with `nonce must be greater than x` before, this fixes that problem.